### PR TITLE
Fix code scanning alert no. 30: Expression injection in Actions

### DIFF
--- a/.github/workflows/go-work-sync.yaml
+++ b/.github/workflows/go-work-sync.yaml
@@ -76,4 +76,6 @@ jobs:
       if: steps.changed.outputs.changed
       run: |
         git show
-        git push origin ${{ github.head_ref }}
+        git push origin "$GITHUB_HEAD_REF"
+      env:
+        GITHUB_HEAD_REF: ${{ github.head_ref }}


### PR DESCRIPTION
Fixes [https://github.com/ranma2913/rancher-desktop/security/code-scanning/30](https://github.com/ranma2913/rancher-desktop/security/code-scanning/30)

To fix the problem, we should avoid directly using the `${{ github.head_ref }}` expression in the `git push` command. Instead, we should assign the value to an environment variable and then use that variable in the shell command. This approach ensures that the value is treated as a plain string by the shell, preventing any potential command injection.

Specifically, we need to:
1. Define an environment variable for `github.head_ref`.
2. Use the environment variable in the `git push` command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
